### PR TITLE
Fix: Unable to Run Server

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,0 +1,17 @@
+module.exports = {
+  "env": {
+    "commonjs": true,
+    "es6": true,
+    "node": true
+  },
+  "extends": "eslint:recommended",
+  "globals": {
+    "Atomics": "readonly",
+    "SharedArrayBuffer": "readonly"
+  },
+  "parserOptions": {
+    "ecmaVersion": 2018
+  },
+  "rules": {
+  }
+};

--- a/lib/adapter/index.js
+++ b/lib/adapter/index.js
@@ -1,7 +1,7 @@
 var WebSocketServer = require('ws').Server;
 var sockjs = require('sockjs');
 
-/** 
+/**
  * Instantiating WebSocketServer by default
  * other options provide adapters
  */
@@ -35,7 +35,7 @@ function SockJsAdapter(config) {
                                     conn.on(event, eventHandler);
                             }
                         },
-                        send: function (data, options) {
+                        send: function (data /*, options*/) {
                             return conn.write(data);
                         },
                         close: function () {

--- a/lib/config.js
+++ b/lib/config.js
@@ -7,7 +7,7 @@ module.exports = function buildConfig(config) {
         path: config.path || "/stomp",
         heartbeat: config.heartbeat || [0, 0],
         heartbeatErrorMargin: config.heartbeatErrorMargin || 1000,
-        debug: config.debug || function (args) {},
+        debug: config.debug || function () {},
         protocol: config.protocol || 'ws'
     };
 

--- a/lib/frame.js
+++ b/lib/frame.js
@@ -39,7 +39,6 @@ function Frame(args) {
   }
 
   this.toStringOrBuffer = function () {
-    console.log('Frame.toStringOrBuffer');
     var header_strs = [],
       frame = '';
 

--- a/lib/frame.js
+++ b/lib/frame.js
@@ -5,7 +5,7 @@ function mkBuffer(headers, body) {
   var buf = new Buffer(hBuf.length + body.length + 1);
   hBuf.copy(buf);
   body.copy(buf, hBuf.length);
-  buf[buf.length - 1] = Bytes.NULL;
+  buf[buf.length - 1] = bytes.NULL;
   return buf;
 }
 
@@ -39,6 +39,7 @@ function Frame(args) {
   }
 
   this.toStringOrBuffer = function () {
+    console.log('Frame.toStringOrBuffer');
     var header_strs = [],
       frame = '';
 

--- a/package.json
+++ b/package.json
@@ -4,6 +4,8 @@
   "description": "Simple STOMP 1.1 Broker for nodejs http applications.",
   "main": "stompServer.js",
   "scripts": {
+    "preversion": "npm run lint && npm run test",
+    "prepublishOnly": "npm run lint && npm run test",
     "lint": "eslint stompServer.js lib",
     "test": "mocha"
   },

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "description": "Simple STOMP 1.1 Broker for nodejs http applications.",
   "main": "stompServer.js",
   "scripts": {
+    "lint": "eslint stompServer.js lib",
     "test": "mocha"
   },
   "repository": {
@@ -28,6 +29,7 @@
   },
   "devDependencies": {
     "chai": "^4.1.2",
+    "eslint": "^5.15.1",
     "mocha": "^5.1.1",
     "stompjs": "^2.3.3"
   }

--- a/stompServer.js
+++ b/stompServer.js
@@ -1,5 +1,3 @@
-var http            = require('http');
-var WebSocketServer = require('ws').Server;
 var EventEmitter    = require('events');
 var util            = require('util');
 
@@ -26,9 +24,9 @@ var buildConfig     = require('./lib/config');
 /**
  * @class
  * @augments EventEmitter
- * 
+ *
  * Create Stomp server with config
- * 
+ *
  * @param {ServerConfig} config Configuration for STOMP server
  */
 var StompServer = function (config) {
@@ -37,12 +35,12 @@ var StompServer = function (config) {
   if (config === undefined) {
     config = {};
   }
-  
-  this.conf = buildConfig(config);  
+
+  this.conf = buildConfig(config);
 
   this.subscribes = [];
   this.middleware = {};
-  this.frameHandler = new Stomp.FrameHandler(this);
+  this.frameHandler = new stomp.FrameHandler(this);
 
   this.socket = new protocolAdapter[this.conf.protocol]({
       server: this.conf.server,
@@ -134,7 +132,8 @@ var StompServer = function (config) {
    * @type {object}
    * @property {string} sessionId
    * */
-  this.onDisconnect = withMiddleware('disconnect', function (socket, receiptId) {
+  this.onDisconnect = withMiddleware('disconnect', function (socket /*, receiptId*/) {
+    // TODO: Do we need to do anything with receiptId on disconnect?
     this.afterConnectionClose(socket);
     this.conf.debug('DISCONNECT', socket.sessionId);
     this.emit('disconnected', socket.sessionId);


### PR DESCRIPTION
Fixed some errors from variable names that had incorrect cases.

- Added eslint.
- Fixed linting errors that caused things not to run.
- Added `preversion` and `prepublishOnly` npm hooks that lint and test.
